### PR TITLE
egne databaser for admin og leader

### DIFF
--- a/API.py
+++ b/API.py
@@ -34,31 +34,92 @@ api = Api(app,
           doc='/api/'
         )
 
-#defines namespace
-ns_Post = api.namespace('api/post', description='POST Endpoints')
-ns_Get = api.namespace('api/get', description='GET Endpoints')
+'''Defines namespaces'''
+#defines namespace all users.
+user_post = api.namespace('api/user/post', description='POST Endpoints')
+user_get = api.namespace('api/user/get', description='GET Endpoints')
+#defines namespace for admin users.
+admin_post = api.namespace('api/admin/post', description='POST Endpoints')
+admin_get = api.namespace('api/admin/get', description='GET Endpoints')
+#defines namespace for leader users.
+leader_post = api.namespace('api/leader/post', description='POST Endpoints')
+leader_get = api.namespace('api/leader/get', description='GET Endpoints')
+#defines namespace for operator users.
+operator_post = api.namespace('api/operator/post', description='POST Endpoints')
+operator_get = api.namespace('api/operator/get', description='GET Endpoints')
 
 #Sets up sessions
 Session(app)
 
-#Gets the test route
-get_test.test_route(ns_Get)
+#Routes for the API
+'''
+  ------------------------
+|                         |
+|   Routes for all users  |
+V                         V
+'''
 
-#Gets the test admin route
-get_test_admin.test_admin_route(ns_Get)
+'''GET - api/user/get'''
 
-#Gets the login route
-post_login.login_route(ns_Post)
+#Test route
+get_test.test_route(user_get)
+#Logout route
+get_logout.logout_route(user_get)
+#Create user route
+post_createUser.create_user(user_post)
 
-#Gets the logout route
-get_logout.logout_route(ns_Get)
+'''POST - api/user/post'''
+#Login route
+post_login.login_route(user_post)
+#Update password route
+post_updatePassword.update_password_route(user_post)
 
-#Gets the create user route
-post_createUser.create_user(ns_Post)
 
-#Gets the update password route
-post_updatePassword.update_password_route(ns_Post)
-    
-#Runs the APP/API
+'''
+  ----------------------------
+ |                            |
+ |   Routes for Admin users   |
+ V                            V
+'''
+
+'''GET - api/admin/get'''
+
+#Test admin route
+get_test_admin.test_admin_route(admin_get)
+
+'''POST - api/admin/post'''
+#POST
+
+
+'''
+  --------------------------                       
+ |                          |
+ |    Routes for Leaders    |
+ V                          V
+'''
+
+'''GET - api/leader/get'''
+#GET
+
+'''POST - api/leader/post'''
+#POST
+
+
+'''
+  ---------------------------
+ |                           |
+ |    Routes for Operators   |
+ V                           V
+'''
+
+'''GET - api/operator/get'''
+#GET
+
+'''POST - api/operator/post'''
+#POST
+
+
+'''Runs the API'''
 if __name__ == "__main__":
-    app.run(debug=True, port=5001)
+    #Hosts the API on port 5001 and sets debug to True
+    app.run(host='0.0.0.0',debug=True, port=5001)

--- a/Requests/GET_R/logout.py
+++ b/Requests/GET_R/logout.py
@@ -14,7 +14,11 @@ from Common.Requirements.session_req import require_session
 def logout_route(ns):
     @ns.route('/logout')
     class logout(Resource):
-        @ns.doc('Logout')
+        @ns.doc('Logout',
+                description='Logout route, logs user out and returns a goodbye message, with Logout: True/False',
+                responses={200: 'OK', 
+                           400: 'Invalid Argument', 
+                           500: 'Mapping Key Error'})
         @require_session
         def get(self):
             user_session = SH.UserSession(session)

--- a/Requests/GET_R/test.py
+++ b/Requests/GET_R/test.py
@@ -8,12 +8,16 @@ import sys
 sys.path.append(os.path.join(current_directory))
 
 from Common.Requirements.session_req import require_session
-from Common.Requirements.admin_req import require_admin_account
 
 def test_route(ns):
+
     @ns.route('/test')
     class Test(Resource):
-        @ns.doc('test')
+        @ns.doc('test',
+                description='Test route, returns OK if the API is running and the user is logged in.',
+                responses={200: 'OK', 
+                           400: 'Invalid Argument', 
+                           500: 'Mapping Key Error'})
         #requirements
         @require_session
         #@require_admin_account  

--- a/Requests/GET_R/test_admin.py
+++ b/Requests/GET_R/test_admin.py
@@ -15,7 +15,12 @@ from Common.Requirements.admin_req import require_admin_account
 def test_admin_route(ns):
     @ns.route('/test_admin')
     class Test(Resource):
-        @ns.doc('test_admin')
+        @ns.doc('test_admin',
+                description='Test route, returns OK if the API is running and the user is logged in as Admin.',
+                responses={200: 'OK', 
+                           400: 'Invalid Argument', 
+                           500: 'Mapping Key Error'})
+
         #requirements
         @require_session
         @require_admin_account  

--- a/Requests/POST_R/createUser.py
+++ b/Requests/POST_R/createUser.py
@@ -16,7 +16,13 @@ def create_user(ns):
     @ns.route('/createUser')
     class CreateLeaderUser(Resource):
         new_user_model = UM.user_model(ns)
-        @ns.doc('create_user')
+        @ns.doc('create_user',
+                description='Create new user when given Email, Password and Account type.',
+                responses={
+                    200: 'OK',
+                    400: 'Invalid Argument or faulty data',
+                    500: 'Internal server error'
+                })
 
         #expects user model from post request
         @ns.expect(new_user_model, validate=True)

--- a/Requests/POST_R/login.py
+++ b/Requests/POST_R/login.py
@@ -19,7 +19,14 @@ def login_route(ns):
     @ns.route('/login')
     class login(Resource):
         new_login_model = UM.login_model(ns)
-        @ns.doc('login')
+        @ns.doc('login',
+                description='Logs user in when given Username and Password. This will create a new session for the user.',
+                responses={
+                    200: 'OK',
+                    400: 'Invalid Argument or faulty data',
+                    500: 'Internal server error'
+                })
+
         @ns.expect(new_login_model, validate=True)
         def post(self):
 

--- a/Requests/POST_R/updatePassword.py
+++ b/Requests/POST_R/updatePassword.py
@@ -20,7 +20,14 @@ def update_password_route(ns):
     @ns.route('/updatePassword')
     class UpdatePassword(Resource):
         new_password_model = UM.update_password_model(ns)
-        @ns.doc('/updatePassword')
+        @ns.doc('/updatePassword',
+                description='Updates a users password when given new password and a exact duplicate of the new password.\n\nRequires a valid session.',
+                responses={
+                    200: 'OK',
+                    400: 'Invalid Argument or faulty data',
+                    500: 'Internal server error'
+                })
+        
         @ns.expect(new_password_model, validate=True)
 
         #requires valid session

--- a/SQLAdminConnections/SQL_AdminQuerys.py
+++ b/SQLAdminConnections/SQL_AdminQuerys.py
@@ -42,10 +42,10 @@ class SQLQueries:
     '''
     @staticmethod
     # Inserts new user credentials into the user_info table
-    def save_user_credentials(email, password, accountType='leader'):
+    def save_user_credentials(email, password, accountType, databaseName='None'):
         # Assuming password is already hashed before calling this method
-        query = "INSERT INTO user_info(email, userPass, accountType) VALUES (%s, %s, %s);"
-        params = (email, password, accountType)
+        query = "INSERT INTO user_info(email, userPass, accountType,databaseName) VALUES (%s, %s, %s, %s);"
+        params = (email, password,accountType,databaseName)
         return query, params
 
     @staticmethod

--- a/SQLAdminConnections/SQL_CreateNewAdminUser.py
+++ b/SQLAdminConnections/SQL_CreateNewAdminUser.py
@@ -2,6 +2,8 @@ from SQLAdminConnections import SQL_AdminConnector as SQLC
 from SQLAdminConnections import SQL_AdminQuerys as SQLQ
 
 def createNewAdminUser(email, password, accountType):
+    #sets up database name
+    databaseName = "DB_"+email
     #makes object of SQLConAdmin class
     adminConnection = SQLC.SQLConAdmin()
 
@@ -14,23 +16,20 @@ def createNewAdminUser(email, password, accountType):
         connection.execute_query(SQLQ.SQLQueries.create_user(email, password))
         
         #Create the new database
-        #query = SQLQueries.create_database(databaseName)
-        #connector.execute_query(query)
-        
+        query = SQLQ.SQLQueries.create_database(databaseName)
+        connection.execute_query(query)
         #Grant the new user privileges on the new database
-        #query = SQLQueries.grant_access(databaseName, email)
-        #connector.execute_query(query)
+        query = SQLQ.SQLQueries.grant_access(databaseName, email)
+        connection.execute_query(query)
         
         #Flush privileges
-        #query = SQLQueries.flush_privileges()
-        #connector.execute_query(query)
+        query = SQLQ.SQLQueries.flush_privileges()
+        connection.execute_query(query)
         
         #Add user details to the users database
-        #Add user details to the users database
-
         connection.execute_query(SQLQ.SQLQueries.use_users_database())
 
-        connection.execute_query(SQLQ.SQLQueries.save_user_credentials(email, password, accountType))
+        connection.execute_query(SQLQ.SQLQueries.save_user_credentials(email, password, accountType, databaseName))
         
         connection.cnx.commit()
         

--- a/SQLAdminConnections/SQL_CreateNewLeaderUser.py
+++ b/SQLAdminConnections/SQL_CreateNewLeaderUser.py
@@ -2,6 +2,8 @@ from SQLAdminConnections import SQL_AdminConnector as SQLC
 from SQLAdminConnections import SQL_AdminQuerys as SQLQ
 
 def createNewLeaderUser(email, password, accountType):
+    #sets up database name
+    databaseName = "DB_"+email
     #makes object of SQLConAdmin class
     adminConnection = SQLC.SQLConAdmin()
 
@@ -14,26 +16,22 @@ def createNewLeaderUser(email, password, accountType):
         connection.execute_query(SQLQ.SQLQueries.create_user(email, password))
         
         #Create the new database
-        #query = SQLQueries.create_database(databaseName)
-        #connector.execute_query(query)
+        query = SQLQ.SQLQueries.create_database(databaseName)
+        connection.execute_query(query)
         
         #Grant the new user privileges on the new database
-        #query = SQLQueries.grant_access(databaseName, email)
-        #connector.execute_query(query)
+        query = SQLQ.SQLQueries.grant_access(databaseName, email)
+        connection.execute_query(query)
         
         #Flush privileges
-        #query = SQLQueries.flush_privileges()
-        #connector.execute_query(query)
+        query = SQLQ.SQLQueries.flush_privileges()
+        connection.execute_query(query)
         
         #Add user details to the users database
-        #Add user details to the users database
-
         connection.execute_query(SQLQ.SQLQueries.use_users_database())
-
-        connection.execute_query(SQLQ.SQLQueries.save_user_credentials(email, password, accountType))
+        connection.execute_query(SQLQ.SQLQueries.save_user_credentials(email, password, accountType, databaseName))
         
         connection.cnx.commit()
-        
         connection.close()
 
     except Exception as e:

--- a/SQLAdminConnections/SQL_CreateNewOperatorUser.py
+++ b/SQLAdminConnections/SQL_CreateNewOperatorUser.py
@@ -12,14 +12,13 @@ def createNewOperatorUser(email, password,accountType):
     try:
         #Create the new user
         connection.execute_query(SQLQ.SQLQueries.create_user(email, password))
-        
+
         #Add user details to the users database
         connection.execute_query(SQLQ.SQLQueries.use_users_database())
-
         connection.execute_query(SQLQ.SQLQueries.save_user_credentials(email, password, accountType))
-
+        
+        #Commit changes and close connection
         connection.cnx.commit()
-
         connection.close()
 
     except Exception as e:

--- a/SQL_setup/userdatabase.sql
+++ b/SQL_setup/userdatabase.sql
@@ -6,7 +6,8 @@ CREATE TABLE user_info(
     id INT AUTO_INCREMENT PRIMARY KEY,
     email VARCHAR(50) UNIQUE,
     accountType VARCHAR(255),
-    userPass VARCHAR(255),  -- Hashed pass
+    databaseName VARCHAR(255) UNIQUE,
+    userPass VARCHAR(255), 
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
Gjort endringer for createuser funksjonalitet, hvor: hvis konto som blir opprettet er admin eller leader, blir de tildelt en egen database hvor tables kan opprettes og håndteres. Ryddet i API.py også for klargjøring av utvidelse. lagt til en column for database navn i sql. Nye leaders og admins for databasenavn automatisk som er "DB_ + email". operators får 'None'.

Sortert requester etter brukere. Vil nå være enklere å se hvilke requester man bruker i API gui.

![image](https://github.com/Bjorgeh/rapportsystem-backend/assets/122554284/d33fa624-f12a-4556-b56c-590dd7d74f38)
