### PR TITLE
replaced @ and . with '_' in email.

### DIFF
--- a/SQLAdminConnections/SQL_CreateNewAdminUser.py
+++ b/SQLAdminConnections/SQL_CreateNewAdminUser.py
@@ -9,8 +9,11 @@ from Requests.CreateRapport import RapportMaker as RM
 
 
 def createNewAdminUser(email, password, accountType):
-    #sets up database name
-    databaseName = "DB_"+email
+
+    #sets up database name and email - Formats email to be used as database & table name
+    databaseName = "DB_"+email.replace("@", "_").replace(".", "_")
+    onlyEmail = email.replace("@", "_").replace(".", "_")
+
     #makes object of SQLConAdmin class
     adminConnection = SQLC.SQLConAdmin()
 
@@ -27,7 +30,7 @@ def createNewAdminUser(email, password, accountType):
         connection.execute_query(query)
 
         #Use the new database
-        query = SQLQ.SQLQueries.use_database("DB_"+email)
+        query = SQLQ.SQLQueries.use_database(databaseName)
 
         #Grant the new user privileges on the new database
         query = SQLQ.SQLQueries.grant_access(databaseName, email)
@@ -51,14 +54,15 @@ def createNewAdminUser(email, password, accountType):
     finally:
         connection.close()
 
+        #innitializes the RapportMaker class
         RapportSetup = RM.RapportMaker()
 
         #Creates rapports for the new user and returns status information
-        return {RapportSetup.createRapport(email, "Disa"),
-                RapportSetup.createRapport(email, "Skrap"),
-                RapportSetup.createRapport(email, "Smelte"),
-                RapportSetup.createRapport(email, "Borreprove"),
-                RapportSetup.createRapport(email, "Sandanalyse")}
+        return {RapportSetup.createRapport(onlyEmail, "Disa"),
+                RapportSetup.createRapport(onlyEmail, "Skrap"),
+                RapportSetup.createRapport(onlyEmail, "Smelte"),
+                RapportSetup.createRapport(onlyEmail, "Borreprove"),
+                RapportSetup.createRapport(onlyEmail, "Sandanalyse")}
 
         
 

--- a/USER_obj/new_user.py
+++ b/USER_obj/new_user.py
@@ -18,7 +18,6 @@ class createUser:
         self.accountType = accountType
         self.databaseName = None
 
-
     #saves user to database
     def saveToDB(self):
         if self.accountType == "admin":


### PR DESCRIPTION
API will now create admins database and tables with the users email adress without "@" and "." This new solution wont affect anything other than db name and table name for an admin user.
Users can still login with normal email. 

![image](https://github.com/Bjorgeh/rapportsystem-backend/assets/122554284/6d435439-743b-4db0-82c1-afa4a05f895d)
